### PR TITLE
feat: Attach container to bone

### DIFF
--- a/src/Spine.ts
+++ b/src/Spine.ts
@@ -406,7 +406,7 @@ export class Spine extends Container implements View
         this.debug = undefined;
         this.skeleton = null as any;
         this.state = null as any;
-        this._mappings = null as any;
+        (this._mappings as any) = null;
     }
 
     /** Whether or not to round the x/y position of the sprite. */

--- a/src/Spine.ts
+++ b/src/Spine.ts
@@ -278,6 +278,13 @@ export class Spine extends Container implements View
         this.debug?.renderDebug(this);
     }
 
+    /**
+     * Attaches a PixiJS container to a specified bone. This will map the world transform of the bone
+     * to the attached container. A container can only be attached to one bone at a time.
+     *
+     * @param container - The container to attach to the bone
+     * @param bone - The bone id or  bone to attach to
+     */
     attachToBone(container:Container, bone:string | Bone)
     {
         this.detachFromBone(container, bone);
@@ -302,6 +309,12 @@ export class Spine extends Container implements View
         });
     }
 
+    /**
+     * Removes a PixiJS container from the bone it is attached to.
+     *
+     * @param container - The container to detach from the bone
+     * @param bone - The bone id or  bone to detach from
+     */
     detachFromBone(container:Container, bone:string | Bone)
     {
         if (typeof bone === 'string')
@@ -320,6 +333,11 @@ export class Spine extends Container implements View
             mapping.bone !== bone && mapping.container !== container);
     }
 
+    /**
+     * A helper function to get an array of all the bone names from the Skeleton.
+     *
+     * @returns The names of the bones in the skeleton
+     */
     getBoneNames()
     {
         return this.skeleton.bones.map((bone) => bone.data.name);

--- a/src/Spine.ts
+++ b/src/Spine.ts
@@ -323,8 +323,16 @@ export class Spine extends Container implements View
 
         this.removeChild(container);
 
-        this._mappings = this._mappings.filter((mapping) =>
-            mapping.bone !== bone && mapping.container !== container);
+        for (let i = 0; i < this._mappings.length; i++)
+        {
+            const mapping = this._mappings[i];
+
+            if (mapping.bone === bone && mapping.container === container)
+            {
+                this._mappings.splice(i, 1);
+                break;
+            }
+        }
     }
 
     /**

--- a/src/Spine.ts
+++ b/src/Spine.ts
@@ -85,6 +85,9 @@ export class Spine extends Container implements View
     public state: AnimationState;
     public skeletonBounds: SkeletonBounds;
     private _debug?: ISpineDebugRenderer | undefined = undefined;
+
+    private _mappings:{bone:Bone, container:Container}[] = [];
+
     public get debug(): ISpineDebugRenderer | undefined
     {
         return this._debug;

--- a/src/Spine.ts
+++ b/src/Spine.ts
@@ -335,16 +335,6 @@ export class Spine extends Container implements View
         }
     }
 
-    /**
-     * A helper function to get an array of all the bone names from the Skeleton.
-     *
-     * @returns The names of the bones in the skeleton
-     */
-    getBoneNames()
-    {
-        return this.skeleton.bones.map((bone) => bone.data.name);
-    }
-
     updateBounds()
     {
         this._boundsDirty = false;

--- a/src/Spine.ts
+++ b/src/Spine.ts
@@ -86,7 +86,7 @@ export class Spine extends Container implements View
     public skeletonBounds: SkeletonBounds;
     private _debug?: ISpineDebugRenderer | undefined = undefined;
 
-    private _mappings:{bone:Bone, container:Container}[] = [];
+    private readonly _mappings:{bone:Bone, container:Container}[] = [];
 
     public get debug(): ISpineDebugRenderer | undefined
     {
@@ -404,6 +404,7 @@ export class Spine extends Container implements View
         this.debug = undefined;
         this.skeleton = null as any;
         this.state = null as any;
+        this._mappings = null as any;
     }
 
     /** Whether or not to round the x/y position of the sprite. */

--- a/src/Spine.ts
+++ b/src/Spine.ts
@@ -27,7 +27,7 @@
  * SPINE RUNTIMES, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *****************************************************************************/
 
-import { Assets, Bounds, Cache, Container, ContainerOptions, DestroyOptions, PointData, Ticker, View } from 'pixi.js';
+import { Assets, Bounds, Cache, Container, ContainerOptions, DEG_TO_RAD, DestroyOptions, PointData, Ticker, View } from 'pixi.js';
 import { getSkeletonBounds } from './getSkeletonBounds';
 import { ISpineDebugRenderer } from './SpineDebugRenderer';
 import {
@@ -239,18 +239,12 @@ export class Spine extends Container implements View
             container.scale.x = bone.getWorldScaleX();
             container.scale.y = bone.getWorldScaleY();
 
-            // Assuming bone is your Spine bone object
-            const rotationX = bone.getWorldRotationX();
-            const rotationY = bone.getWorldRotationY();
+            const rotationX = bone.getWorldRotationX() * DEG_TO_RAD;
+            const rotationY = bone.getWorldRotationY() * DEG_TO_RAD;
 
-            // Convert degrees to radians
-            const rotationXRad = rotationX * (Math.PI / 180);
-            const rotationYRad = rotationY * (Math.PI / 180);
-
-            // Combine rotations using trigonometry
             container.rotation = -Math.atan2(
-                Math.sin(rotationXRad) + Math.sin(rotationYRad),
-                Math.cos(rotationXRad) + Math.cos(rotationYRad)
+                Math.sin(rotationX) + Math.sin(rotationY),
+                Math.cos(rotationX) + Math.cos(rotationY)
             );
         });
         this.onViewUpdate();

--- a/src/Spine.ts
+++ b/src/Spine.ts
@@ -27,7 +27,17 @@
  * SPINE RUNTIMES, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *****************************************************************************/
 
-import { Assets, Bounds, Cache, Container, ContainerOptions, DEG_TO_RAD, DestroyOptions, PointData, Ticker, View } from 'pixi.js';
+import {
+    Assets,
+    Bounds,
+    Cache,
+    Container,
+    ContainerOptions,
+    DEG_TO_RAD,
+    DestroyOptions,
+    PointData, Ticker,
+    View
+} from 'pixi.js';
 import { getSkeletonBounds } from './getSkeletonBounds';
 import { ISpineDebugRenderer } from './SpineDebugRenderer';
 import {


### PR DESCRIPTION
This PR allows for containers to be attached to Bones!

```
const spineBoy = Spine.from({
					skeleton:'spineboySkeletonBinary', 
					atlas:'spineboyAtlas',
					scale:0.75
				 });


const hat = Sprite.from('hat.png');

// attach:
spineBot.attachToBone(hat, 'hair1`);

// detach:
spineBot.detachFromBone(hat, 'hair1`);
```

One note is that the attached items are not depth sorted - and always on top. This is because the spine mesh is currently rendered in one go. Will look into sorting this in a follow up PR.  

also added a little helper function that returns all available bone names `spine.getBoneNames()`