### PR TITLE
fix: Clipped attachments don't have an assigned batcher

### DIFF
--- a/src/SpinePipe.ts
+++ b/src/SpinePipe.ts
@@ -148,7 +148,7 @@ export class SpinePipe implements RenderPipe<Spine>
             {
                 const batchableSpineSlot = gpuSpine.slotBatches[spine._getCachedData(slot, attachment).id];
 
-                batchableSpineSlot.batcher.updateElement(batchableSpineSlot);
+                batchableSpineSlot.batcher?.updateElement(batchableSpineSlot);
             }
         }
     }


### PR DESCRIPTION
When updating the `batchableSpineSlot`, [this assumes the batcher is defined](https://github.com/pixijs/spine-v8/blob/main/src/SpinePipe.ts#L151), but [when an attachment is clipped the batcher is never assigned](https://github.com/pixijs/spine-v8/blob/main/src/SpinePipe.ts#L114) leading to that call crashing because the batcher is undefined. This is just a quick fix to prevent this error.