### PR TITLE
fix: tint and spine skeleton/slot/attachment color

### DIFF
--- a/src/BatchableSpineSlot.ts
+++ b/src/BatchableSpineSlot.ts
@@ -110,7 +110,6 @@ export class BatchableSpineSlot implements BatchableObject
 
         const parentColor:number = this.renderable.groupColor;
         const parentAlpha:number = this.renderable.groupAlpha;
-
         let abgr:number;
 
         const mixedA = (slotColor.a * parentAlpha) * 255;
@@ -121,9 +120,9 @@ export class BatchableSpineSlot implements BatchableObject
             const parentG = (parentColor >> 8) & 0xFF;
             const parentR = parentColor & 0xFF;
 
-            const mixedR = (slotColor.r * parentR) * 255;
-            const mixedG = (slotColor.g * parentG) * 255;
-            const mixedB = (slotColor.b * parentB) * 255;
+            const mixedR = (slotColor.r * parentR);
+            const mixedG = (slotColor.g * parentG);
+            const mixedB = (slotColor.b * parentB);
 
             abgr = ((mixedA) << 24) | (mixedB << 16) | (mixedG << 8) | mixedR;
         }

--- a/src/Spine.ts
+++ b/src/Spine.ts
@@ -100,7 +100,7 @@ export interface AttachmentCacheData
     vertices: Float32Array;
     uvs: Float32Array;
     indices: number[];
-    color: { r: number; g: number; b: number; a: number };
+    color: Color;
     clippedData?: {
         vertices: Float32Array;
         uvs: Float32Array;
@@ -419,6 +419,18 @@ export class Spine extends Container implements View
                         );
                     }
 
+                    const skeleton = slot.bone.skeleton;
+                    const skeletonColor = skeleton.color;
+                    const slotColor = slot.color;
+                    const attachmentColor = attachment.color;
+
+                    cacheData.color.set(
+                        skeletonColor.r * slotColor.r * attachmentColor.r,
+                        skeletonColor.g * slotColor.g * attachmentColor.g,
+                        skeletonColor.b * slotColor.b * attachmentColor.b,
+                        skeletonColor.a * slotColor.a * attachmentColor.a,
+                    );
+
                     cacheData.clipped = false;
 
                     if (clipper.isClipping())
@@ -570,7 +582,7 @@ export class Spine extends Container implements View
                 clipped: false,
                 indices: [0, 1, 2, 0, 2, 3],
                 uvs: attachment.uvs as Float32Array,
-                color: slot.color,
+                color: new Color(1, 1, 1, 1),
             };
         }
         else
@@ -583,7 +595,7 @@ export class Spine extends Container implements View
                 clipped: false,
                 indices: attachment.triangles,
                 uvs: attachment.uvs as Float32Array,
-                color: slot.color,
+                color: new Color(1, 1, 1, 1),
             };
         }
 


### PR DESCRIPTION
This PR should fix two issues about colors:

- Fix the tint issue reported here: https://github.com/pixijs/spine-v8/issues/18
- Fix the final attachment color. The attachment color is the result of the skeleton, slot and attachment color. Previously only the slot color was used. You can see this from the white part in the hair of the girl in [this example](https://pixijs.io/spine-v8/examples/mix-and-match-example.html). Hair is colored using the attachment color, not the slot color.