### PR TITLE
fix: clipping not working properly

### DIFF
--- a/src/Spine.ts
+++ b/src/Spine.ts
@@ -433,8 +433,10 @@ export class Spine extends Container implements View
                 else
                 {
                     clipper.clipEndWithSlot(slot);
+                    continue;
                 }
             }
+            clipper.clipEndWithSlot(slot);
         }
 
         clipper.clipEnd();


### PR DESCRIPTION
This PR fixes a couple of problem with clipping:

- clipping was not always attempted to be ended
- when `spinePipe.addRenderable` is called with a `cacheData.clippedData.vertexCount` set at `0`, but `cacheData.clippedData.vertices.length` is bigger than `0`, it was still added to the batch, generating a `GL_INVALID_OPERATION: Insufficient buffer size.` on webgl and a `Calling [RenderPassEncoder (unlabeled)].Draw with an index count of 0 is unusual.` on webgpu
- when `spinePipe.updateRenderable` is called, the `batcher.updateElement` was called regardless of the fact the attachment has zero _clipped vertices_ to draw; however, the `vertexSize` of the `BatchableSpineSlot` is never set to zero becuase `addRenderable` set it only if vertices are more than zero. I added an if into `updateRenderable`, otherwise we can move the `batchableSpineSlot.setData` outside the if in the `addRenderable`
- Removed a useless clipper from the SpinePipe

I'm not an expert of `RenderPipe`, so let me know if I did some wrong assumption :)