### PR TITLE
fix: pma textures are requested to be loaded as already premultiplied

### DIFF
--- a/src/assets/atlasLoader.ts
+++ b/src/assets/atlasLoader.ts
@@ -120,7 +120,15 @@ const spineTextureAtlasLoader: AssetExtension<RawAtlas | TextureAtlas, ISpineAtl
                     // eslint-disable-next-line max-len
                     const url: string = providedPage ?? path.normalize([...basePath.split(path.sep), pageName].join(path.sep));
 
-                    const pixiPromise = loader.load<Texture>({ src: url, data: metadata.imageMetadata }).then((texture) =>
+                    const assetsToLoadIn = {
+                        src: url,
+                        data: {
+                            ...metadata.imageMetadata,
+                            alphaMode: page.pma ? 'premultiplied-alpha' : 'premultiply-alpha-on-upload'
+                        }
+                    };
+
+                    const pixiPromise = loader.load<Texture>(assetsToLoadIn).then((texture) =>
                     {
                         page.setTexture(SpineTexture.from(texture.source));
                     });


### PR DESCRIPTION
A Spine atlas txt files that are generate in conjunction with the respective atlas textures contains a `pma` option that holds the information regarding the textures beinga premultiplied or not.
This information can be used to inform the texture loader to premultiply or not the texture on load.

This PR allows to use the `pma` information and to request to the pixi texture loader to premultiply the texture or not.

When `webgpu` is used, this is sufficient.
However, when `webgl` is used, it is necessary to set  on `PIXI.Assets` the `preferWorkers` to `false` when Spine premultiplied textures are loaded because currently when `createImageBitmap` is used, the given `alphaMode` is ignored. This can be avoided if this other PR is merged: https://github.com/pixijs/pixijs/pull/10803

If this PRs are merged, it would be cool if the [blog news examples](https://pixijs.com/blog/pixi-js-hearts-spine) would be regenerated to use this fix. Currently, all textures have the problem of using pma textures, but are loaded without taking this in consideration.