### PR TITLE
fix: textures change was not take into account

### DIFF
--- a/src/Spine.ts
+++ b/src/Spine.ts
@@ -402,6 +402,7 @@ export class Spine extends Container implements View
                 if (attachment instanceof MeshAttachment || attachment instanceof RegionAttachment)
                 {
                     const cacheData = this._getCachedData(slot, attachment);
+                    const previousAttachment = attachment.region?.texture.texture;
 
                     if (attachment instanceof RegionAttachment)
                     {
@@ -418,6 +419,8 @@ export class Spine extends Container implements View
                             2,
                         );
                     }
+
+                    if (attachment.region.texture.texture !== previousAttachment) this.spineAttachmentsDirty = true;
 
                     cacheData.clipped = false;
 


### PR DESCRIPTION
In Spine, during an animation, it can happen that a texture is changed for the same attachment (this happens for sequences).

A texture change should lead to an `addRenderable` call. However, the Spine `validateAttachments` doesn't take into consideration the texture change and does not set the `spineAttachmentsDirty` to `true` in that case.

This PR allowsto take this into account and provide a way to set `spineAttachmentsDirty` to `true`.
However, it does not do that in the `validateAttachments`.

The only way to do that would be:
- change the order of `validateAttachments` and `transformAttachments`
- store somewhere that a texture changed

I'll keep this as a draft since I didn't think yet how to move the "texture validation" within the `validateAttachments` function.

This PR fixes this: https://github.com/pixijs/spine-v8/issues/26







