### PR TITLE
fix: clipping termination on same slot, always set dirty when vertex …

### DIFF
--- a/src/Spine.ts
+++ b/src/Spine.ts
@@ -442,14 +442,11 @@ export class Spine extends Container implements View
                 else if (attachment instanceof ClippingAttachment)
                 {
                     clipper.clipStart(slot, attachment);
-                }
-                else
-                {
-                    clipper.clipEndWithSlot(slot);
+                    continue;
                 }
             }
+            clipper.clipEndWithSlot(slot);
         }
-
         clipper.clipEnd();
     }
 
@@ -492,7 +489,7 @@ export class Spine extends Container implements View
 
         cacheData.skipRender = verticesCount === 0;
 
-        if (sizeChange && !cacheData.skipRender)
+        if (sizeChange)
         {
             this.spineAttachmentsDirty = true;
 


### PR DESCRIPTION
This PR fixes two issues with clipping.

The first is reported here: https://github.com/pixijs/spine-v8/issues/33#issuecomment-2273237852
Clipping is not correctly terminated when the clipper is clipping. The logic is now changed so that clip termination is always attempted unless the attachment is a `ClippingAttachment`.

The second fix changes the condition on which `updateClippingData` set the Spine object as dirty. Currently, it sets is as dirty if `sizeChange && !cacheData.skipRender`, that means if vertices/indexes changed size and `verticesCount > 0`.

However, when transitioning from a positive number of vertices to 0 vertices, if we don't set the Spine object as dirty, `updateRenderable` is called and the respective `BatchableSpineSlot` data is not updated. This means that the latest vertices are rendered for a slot that should have 0 vertices.

For both cases, we can find a repro here: [export.zip](https://github.com/user-attachments/files/16529474/export.zip)

For the second issue, the white square should completely disappear at the end of the jump. Currently, it remains stuck in the middle of the jump.