### PR TITLE
fix: uvs array might change if the region is updated and the uvs are more

### DIFF
--- a/src/Spine.ts
+++ b/src/Spine.ts
@@ -420,6 +420,8 @@ export class Spine extends Container implements View
                         );
                     }
 
+                    cacheData.uvs = attachment.uvs as Float32Array;
+
                     const skeleton = slot.bone.skeleton;
                     const skeletonColor = skeleton.color;
                     const slotColor = slot.color;


### PR DESCRIPTION
The `cacheData` structure might hold an old `uvs` array when a region is updated.

The PR just always reassigns the current `uvs` to the cache.
The alternative would have been to check if the uvs length differs like this:

```ts
if (cacheData.uvs !== attachment.uvs)
{
    cacheData.uvs = attachment.uvs as Float32Array;
}
```

But the result would have been almost the same with an additional if check. In general `uvs` array changes very rarely, so in most of the case the if body would not have been executed.
I don't see any performance improvement in keeping that if, so I just removed it and kept only the assignment.

This fixes a bug reported by a user on discord: https://discord.com/channels/734147990985375826/968068622327111681/1270951771564675134