### PR TITLE
Fix dark color not premultiplied by world alpha

### DIFF
--- a/src/BatchableSpineSlot.ts
+++ b/src/BatchableSpineSlot.ts
@@ -101,7 +101,7 @@ export class BatchableSpineSlot implements DefaultBatchableMeshElement
     {
         const darkColor = this.data.darkColor;
 
-        return ((darkColor.a) << 24) | ((darkColor.b * 255) << 16) | ((darkColor.g * 255) << 8) | (darkColor.r * 255);
+        return ((darkColor.b * 255) << 16) | ((darkColor.g * 255) << 8) | (darkColor.r * 255);
     }
 
     get groupTransform() { return this.renderable.groupTransform; }

--- a/src/darktint/DarkTintBatcher.ts
+++ b/src/darktint/DarkTintBatcher.ts
@@ -1,5 +1,6 @@
 import {
     Batcher,
+    Color,
     DefaultBatchableMeshElement,
     DefaultBatchableQuadElement,
     extensions,
@@ -51,7 +52,8 @@ export class DarkTintBatcher extends Batcher
         const { positions, uvs } = element;
 
         const argb = element.color;
-        const darkColor = element.darkColor;
+        const worldAlpha = ((argb >> 24) & 0xFF) / 255;
+        const darkColor = Color.shared.setValue(element.darkColor).premultiply(worldAlpha, true).toPremultiplied(1, false);
 
         const offset = element.attributeOffset;
         const end = offset + element.attributeSize;


### PR DESCRIPTION
I finally found the time to test the dark tint batcher, and it works great!
This PR just fixes a small issue with dark color and PMA.

Dark color in Spine has just RGB and no alpha. However, since in Pixi we expect colors to be premultiplied, we need to premultiply the dark color by the world alpha (which is the alpha resulting from the parent and normal color alpha).

You can test the difference using these skeletons:
- [Coin](https://github.com/EsotericSoftware/spine-runtimes/tree/4.2/examples/coin/export), one of our official examples
- These [orange balls](https://github.com/user-attachments/files/17042696/orangeballz.zip) that test dark tint in the two possible ways color alpha can be controlled in Spine (separated and not separated from RGB).

Here are two screenshots at 10% of the animation time of the Coin example.
Before fix:
<img width="148" alt="image" src="https://github.com/user-attachments/assets/cb30657d-fda3-4679-b139-63540c74d097">

After fix:
<img width="148" alt="image" src="https://github.com/user-attachments/assets/eb0509c8-eb01-4d01-9c5d-a4a211c81ea7">


