### PR TITLE
fix: protecting from TypeError in the SpinePipe.ts

### DIFF
--- a/src/SpinePipe.ts
+++ b/src/SpinePipe.ts
@@ -93,11 +93,11 @@ export class SpinePipe implements RenderPipe<Spine>
                 if (attachment instanceof RegionAttachment || attachment instanceof MeshAttachment)
                 {
                     const cacheData = spine._getCachedData(slot, attachment);
-                    const batchableSpineSlot = gpuSpine.slotBatches[cacheData.id];
+                    const batchableSpineSlot = gpuSpine.slotBatches?.[cacheData.id];
 
                     const texture = cacheData.texture;
 
-                    if (texture !== batchableSpineSlot.texture)
+                    if (batchableSpineSlot && texture !== batchableSpineSlot?.texture)
                     {
                         if (!batchableSpineSlot._batcher.checkAndUpdateTexture(batchableSpineSlot, texture))
                         {
@@ -184,7 +184,7 @@ export class SpinePipe implements RenderPipe<Spine>
                 {
                     const batchableSpineSlot = gpuSpine.slotBatches[spine._getCachedData(slot, attachment).id];
 
-                    batchableSpineSlot._batcher?.updateElement(batchableSpineSlot);
+                    batchableSpineSlot?._batcher?.updateElement(batchableSpineSlot);
                 }
             }
         }


### PR DESCRIPTION
Issue: [https://github.com/pixijs/spine-v8/issues/48](https://github.com/pixijs/spine-v8/issues/48)

I don’t know the cause or if this is the definitive solution.
However, I implemented a protection that resolved the issue to me, and my animations continue to work without the TypeError or the black flicker during rendering.

Protection from this error:
```
TypeError: Cannot read properties of undefined (reading 'texture')
    at SpinePipe.validateRenderable (SpinePipe.mjs:38:1)
    at validateRenderables (validateRenderables.mjs:9:1)
    at RenderGroupSystem.render (RenderGroupSystem.mjs:35:28)
    at SystemRunner.emit (SystemRunner.mjs:19:1)
    at WebGPURenderer.render (AbstractRenderer.mjs:89:1)
```
And after implementing that protection, I had to address another TypeError in the `updateRenderable` method.
